### PR TITLE
Observability

### DIFF
--- a/software/molecule/default/molecule.yml
+++ b/software/molecule/default/molecule.yml
@@ -15,6 +15,7 @@ platforms:
       qemu_dir: /usr/bin/
       arch: x86_64
       machine: q35
+      memory: 2048
       cpu: max
       net_device: virtio-net-pci
     provider_raw_config_args:

--- a/software/roles/docker_compose_apps/templates/authelia/config/configuration.yml.j2
+++ b/software/roles/docker_compose_apps/templates/authelia/config/configuration.yml.j2
@@ -22,6 +22,8 @@ access_control:
       policy: one_factor
     - domain: grocy.{{ base_domain }}
       policy: one_factor
+    - domain: traefik.{{ base_domain }}
+      policy: one_factor
     - domain: grafana.{{ base_domain }}
       policy: one_factor
 

--- a/software/roles/docker_compose_apps/templates/authelia/config/configuration.yml.j2
+++ b/software/roles/docker_compose_apps/templates/authelia/config/configuration.yml.j2
@@ -18,11 +18,11 @@ totp:
 access_control:
   default_policy: deny
   rules:
-    - domain: grafana.{{ base_domain }}
-      policy: one_factor
     - domain: ldap.{{ base_domain }}
       policy: one_factor
     - domain: grocy.{{ base_domain }}
+      policy: one_factor
+    - domain: grafana.{{ base_domain }}
       policy: one_factor
 
 session:

--- a/software/roles/docker_compose_apps/templates/authelia/config/configuration.yml.j2
+++ b/software/roles/docker_compose_apps/templates/authelia/config/configuration.yml.j2
@@ -18,6 +18,8 @@ totp:
 access_control:
   default_policy: deny
   rules:
+    - domain: grafana.{{ base_domain }}
+      policy: one_factor
     - domain: ldap.{{ base_domain }}
       policy: one_factor
     - domain: grocy.{{ base_domain }}

--- a/software/roles/docker_compose_apps/templates/observability/.env.j2
+++ b/software/roles/docker_compose_apps/templates/observability/.env.j2
@@ -1,0 +1,1 @@
+BASE_DOMAIN={{ base_domain }}

--- a/software/roles/docker_compose_apps/templates/observability/config/grafana/datasources.yaml
+++ b/software/roles/docker_compose_apps/templates/observability/config/grafana/datasources.yaml
@@ -1,0 +1,62 @@
+apiVersion: 1
+
+datasources:
+- name: Prometheus
+  type: prometheus
+  uid: prometheus
+  access: proxy
+  orgId: 1
+  url: http://prometheus:9090
+  basicAuth: false
+  isDefault: false
+  version: 1
+  editable: false
+  jsonData:
+    httpMethod: GET
+    exemplarTraceIdDestinations:
+      # Field with internal link pointing to data source in Grafana.
+      # datasourceUid value can be anything, but it should be unique across all defined data source uids.
+      - datasourceUid: tempo
+        name: traceID
+- name: Tempo
+  type: tempo
+  access: proxy
+  orgId: 1
+  url: http://tempo:3200
+  basicAuth: false
+  isDefault: true
+  version: 1
+  editable: false
+  apiVersion: 1
+  uid: tempo
+  jsonData:
+    httpMethod: GET
+    serviceMap:
+      datasourceUid: prometheus
+    tracesToLogs:
+      datasourceUid: loki
+      mappedTags:
+        - key: service.name
+          value: compose_service
+      mapTagNamesEnabled: true
+      spanStartTimeShift: '-1h'
+      spanEndTimeShift: '1h'
+      filterByTraceID: true
+      filterBySpanID: false
+- name: Loki
+  type: loki
+  uid: loki
+  access: proxy
+  orgId: 1
+  url: http://loki:3100
+  basicAuth: false
+  isDefault: false
+  version: 1
+  editable: false
+  apiVersion: 1
+  jsonData:
+    derivedFields:
+      - datasourceUid: tempo
+        matcherRegex: (?:traceID|trace_id)=(\w+)
+        name: TraceID
+        url: $${__value.raw}

--- a/software/roles/docker_compose_apps/templates/observability/config/grafana/grafana.ini
+++ b/software/roles/docker_compose_apps/templates/observability/config/grafana/grafana.ini
@@ -1,0 +1,10 @@
+[users]
+allow_sign_up = false
+auto_assign_org = true
+auto_assign_org_role = Editor
+
+[auth.proxy]
+enabled = true
+header_name = Remote-User
+header_property = username
+auto_sign_up = true

--- a/software/roles/docker_compose_apps/templates/observability/config/grafana/grafana.ini.j2
+++ b/software/roles/docker_compose_apps/templates/observability/config/grafana/grafana.ini.j2
@@ -1,3 +1,6 @@
+[server]
+domain = grafana.{{ base_domain }}
+
 [users]
 allow_sign_up = false
 auto_assign_org = true

--- a/software/roles/docker_compose_apps/templates/observability/config/otel-collector/otel-collector.yaml
+++ b/software/roles/docker_compose_apps/templates/observability/config/otel-collector/otel-collector.yaml
@@ -1,0 +1,52 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+  jaeger:
+    protocols:
+      thrift_http:
+  prometheus:
+    config:
+      global:
+        scrape_interval:     15s
+        evaluation_interval: 15s
+      scrape_configs:
+        - job_name: 'otel-collector'
+          static_configs:
+            - targets: [ 'localhost:8888' ]
+        - job_name: 'prometheus'
+          static_configs:
+            - targets: [ 'prometheus:9090' ]
+        - job_name: 'tempo'
+          static_configs:
+            - targets: [ 'tempo:3200' ]
+        - job_name: 'loki'
+          static_configs:
+            - targets: [ 'loki:3100' ]
+        - job_name: 'promtail'
+          static_configs:
+            - targets: [ 'promtail:9080' ]
+  docker_stats:
+processors:
+  batch:
+exporters:
+  otlp:
+    endpoint: tempo:4317
+    tls:
+      insecure: true
+  prometheus:
+    endpoint: "0.0.0.0:8889"
+service:
+  telemetry:
+    metrics:
+      level: detailed
+      address: 0.0.0.0:8888
+  pipelines:
+    traces:
+      receivers: [otlp, jaeger]
+      processors: [batch]
+      exporters: [otlp]
+    metrics:
+      receivers: [otlp, prometheus]
+      processors: [batch]
+      exporters: [prometheus]

--- a/software/roles/docker_compose_apps/templates/observability/config/otel-collector/otel-collector.yaml
+++ b/software/roles/docker_compose_apps/templates/observability/config/otel-collector/otel-collector.yaml
@@ -27,6 +27,22 @@ receivers:
           static_configs:
             - targets: [ 'promtail:9080' ]
   docker_stats:
+    collection_interval: 15s
+  hostmetrics:
+    root_path: /hostfs
+    collection_interval: 15s
+    scrapers:
+      cpu:
+      disk:
+      load:
+      filesystem:
+      memory:
+      network:
+      paging:
+      processes:
+      process:
+        mute_process_name_error: true
+
 processors:
   batch:
 exporters:
@@ -47,6 +63,6 @@ service:
       processors: [batch]
       exporters: [otlp]
     metrics:
-      receivers: [otlp, prometheus]
+      receivers: [otlp, prometheus, hostmetrics, docker_stats]
       processors: [batch]
       exporters: [prometheus]

--- a/software/roles/docker_compose_apps/templates/observability/config/otel-collector/otel-collector.yaml
+++ b/software/roles/docker_compose_apps/templates/observability/config/otel-collector/otel-collector.yaml
@@ -26,25 +26,10 @@ receivers:
         - job_name: 'promtail'
           static_configs:
             - targets: [ 'promtail:9080' ]
-  docker_stats:
-    collection_interval: 15s
-  hostmetrics:
-    root_path: /hostfs
-    collection_interval: 15s
-    scrapers:
-      cpu:
-      disk:
-      load:
-      filesystem:
-      memory:
-      network:
-      paging:
-      processes:
-      process:
-        mute_process_name_error: true
 
 processors:
   batch:
+
 exporters:
   otlp:
     endpoint: tempo:4317
@@ -52,6 +37,7 @@ exporters:
       insecure: true
   prometheus:
     endpoint: "0.0.0.0:8889"
+
 service:
   telemetry:
     metrics:
@@ -63,6 +49,6 @@ service:
       processors: [batch]
       exporters: [otlp]
     metrics:
-      receivers: [otlp, prometheus, hostmetrics, docker_stats]
+      receivers: [otlp, prometheus]
       processors: [batch]
       exporters: [prometheus]

--- a/software/roles/docker_compose_apps/templates/observability/config/prometheus/prometheus.yaml
+++ b/software/roles/docker_compose_apps/templates/observability/config/prometheus/prometheus.yaml
@@ -1,0 +1,14 @@
+tracing:
+  endpoint: otel-collector:4317
+  sampling_fraction: 1
+  insecure: true
+
+global:
+  scrape_interval:     15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: 'otel'
+    honor_labels: true
+    static_configs:
+      - targets: [ 'otel-collector:8889' ]

--- a/software/roles/docker_compose_apps/templates/observability/config/promtail/promtail.yaml
+++ b/software/roles/docker_compose_apps/templates/observability/config/promtail/promtail.yaml
@@ -1,0 +1,54 @@
+# https://gist.github.com/ruanbekker/c6fa9bc6882e6f324b4319c5e3622460
+server:
+  http_listen_address: 0.0.0.0
+  http_listen_port: 9080
+
+positions:
+  filename: /tmp/positions.yaml
+
+clients:
+  - url: http://loki:3100/loki/api/v1/push
+
+scrape_configs:
+- job_name: containers
+  static_configs:
+  - targets:
+      - localhost
+    labels:
+      job: containerlogs
+      __path__: /var/lib/docker/containers/*/*log
+
+  pipeline_stages:
+  - json:
+      expressions:
+        log: log
+        stream: stream
+        time: time
+        tag: attrs.tag
+        compose_project: attrs."com.docker.compose.project"
+        compose_service: attrs."com.docker.compose.service"
+        stack_name: attrs."com.docker.stack.namespace"
+        swarm_service_name: attrs."com.docker.swarm.service.name"
+        swarm_task_name: attrs."com.docker.swarm.task.name"
+  - regex:
+      expression: "^/var/lib/docker/containers/(?P<container_id>.{12}).+/.+-json.log$"
+      source: filenameattrs
+  - regex:
+      expression: (?P<image_name>(?:[^|]*[^|])).(?P<container_name>(?:[^|]*[^|])).(?P<image_id>(?:[^|]*[^|]))
+      source: tag
+  - timestamp:
+      format: RFC3339Nano
+      source: time
+  - labels:
+      stream:
+      container_id:
+      image_name:
+      container_name:
+      image_id:
+      compose_project:
+      compose_service:
+      stack_name:
+      swarm_service_name:
+      swarm_task_name:
+  - output:
+      source: log

--- a/software/roles/docker_compose_apps/templates/observability/config/promtail/promtail.yaml
+++ b/software/roles/docker_compose_apps/templates/observability/config/promtail/promtail.yaml
@@ -4,7 +4,7 @@ server:
   http_listen_port: 9080
 
 positions:
-  filename: /tmp/positions.yaml
+  filename: /var/promtail/positions.yaml
 
 clients:
   - url: http://loki:3100/loki/api/v1/push

--- a/software/roles/docker_compose_apps/templates/observability/config/tempo/tempo.yaml
+++ b/software/roles/docker_compose_apps/templates/observability/config/tempo/tempo.yaml
@@ -1,0 +1,62 @@
+search_enabled: true
+metrics_generator_enabled: true
+
+server:
+  http_listen_port: 3200
+
+distributor:
+  receivers:                           # this configuration will listen on all ports and protocols that tempo is capable of.
+    jaeger:                            # the receives all come from the OpenTelemetry collector.  more configuration information can
+      protocols:                       # be found there: https://github.com/open-telemetry/opentelemetry-collector/tree/main/receiver
+        thrift_http:                   #
+        grpc:                          # for a production deployment you should only enable the receivers you need!
+        thrift_binary:
+        thrift_compact:
+    zipkin:
+    otlp:
+      protocols:
+        http:
+        grpc:
+    opencensus:
+
+ingester:
+  trace_idle_period: 10s               # the length of time after a trace has not received spans to consider it complete and flush it
+  max_block_bytes: 1_000_000           # cut the head block when it hits this size or ...
+  max_block_duration: 5m               #   this much time passes
+
+compactor:
+  compaction:
+    compaction_window: 1h              # blocks in this time window will be compacted together
+    max_block_bytes: 100_000_000       # maximum size of compacted blocks
+    block_retention: 1h
+    compacted_block_retention: 10m
+
+metrics_generator:
+  registry:
+    external_labels:
+      source: tempo
+      cluster: docker-compose
+  storage:
+    path: /tmp/tempo/generator/wal
+    remote_write:
+      - url: http://prometheus:9090/api/v1/write
+        send_exemplars: true
+
+storage:
+  trace:
+    backend: local                     # backend configuration to use
+    block:
+      bloom_filter_false_positive: .05 # bloom filter false positive rate.  lower values create larger filters but fewer false positives
+      index_downsample_bytes: 1000     # number of bytes per index record
+      encoding: zstd                   # block encoding/compression.  options: none, gzip, lz4-64k, lz4-256k, lz4-1M, lz4, snappy, zstd, s2
+    wal:
+      path: /tmp/tempo/wal             # where to store the the wal locally
+      encoding: snappy                 # wal encoding/compression.  options: none, gzip, lz4-64k, lz4-256k, lz4-1M, lz4, snappy, zstd, s2
+    local:
+      path: /tmp/tempo/blocks
+    pool:
+      max_workers: 100                 # worker pool determines the number of parallel requests to the object store backend
+      queue_depth: 10000
+
+overrides:
+  metrics_generator_processors: [service-graphs, span-metrics]

--- a/software/roles/docker_compose_apps/templates/observability/docker-compose.yml
+++ b/software/roles/docker_compose_apps/templates/observability/docker-compose.yml
@@ -7,8 +7,6 @@ services:
       - grafana_data:/var/lib/grafana
       - ./config/grafana/grafana.ini:/etc/grafana/grafana.ini
     environment:
-      GF_AUTH_ANONYMOUS_ENABLED: "true"
-      GF_AUTH_ANONYMOUS_ORG_ROLE: Admin
       GF_AUTH_DISABLE_LOGIN_FORM: "true"
       JAEGER_AGENT_HOST: otel-collector
       JAEGER_ENDPOINT: http://otel-collector:14268/api/traces
@@ -71,13 +69,10 @@ services:
 
   otel-collector:
     image: otel/opentelemetry-collector-contrib:latest
-    command: [ "--config=/etc/otel-collector.yaml", "--feature-gates=receiver.dockerstats.useScraperV2" ]
-    user: 0:0
+    command: [ "--config=/etc/otel-collector.yaml" ]
     read_only: true
     volumes:
       - ./config/otel-collector/otel-collector.yaml:/etc/otel-collector.yaml:ro
-      - /var/run/docker.sock:/var/run/docker.sock
-      - /:/hostfs
     networks:
       - internal
       - observability
@@ -112,4 +107,4 @@ networks:
   observability:
     name: observability
   rproxy:
-    external: true
+    name: rproxy

--- a/software/roles/docker_compose_apps/templates/observability/docker-compose.yml
+++ b/software/roles/docker_compose_apps/templates/observability/docker-compose.yml
@@ -5,7 +5,8 @@ services:
     ports:
       - 3000:3000
     volumes:
-      - ./config/grafana/datasources.yaml:/etc/grafana/provisioning/datasources/datasources.yaml
+      - ./config/grafana/datasources.yaml:/etc/grafana/provisioning/datasources/datasources.yaml:ro
+      - grafana_data:/var/lib/grafana
     #  - ./config/grafana/grafana.ini:/etc/grafana/grafana.ini
     environment:
       GF_AUTH_ANONYMOUS_ENABLED: "true"
@@ -21,8 +22,9 @@ services:
     image: grafana/tempo:latest
     command: [ "-config.file=/etc/tempo.yaml" ]
     volumes:
-      - ./config/tempo/tempo.yaml:/etc/tempo.yaml
+      - ./config/tempo/tempo.yaml:/etc/tempo.yaml:ro
       - tempo_data:/tmp/tempo
+    read_only: true
     environment:
       JAEGER_AGENT_HOST: otel-collector
       JAEGER_ENDPOINT: http://otel-collector:14268/api/traces
@@ -33,6 +35,9 @@ services:
   loki:
     image: grafana/loki:latest
     command: [ "-config.file=/etc/loki/local-config.yaml" ]
+    read_only: true
+    volumes:
+      - loki_data:/loki
     environment:
       JAEGER_AGENT_HOST: otel-collector
       JAEGER_ENDPOINT: http://otel-collector:14268/api/traces
@@ -46,23 +51,30 @@ services:
       - --config.file=/etc/prometheus.yaml
       - --web.enable-remote-write-receiver
       - --enable-feature=exemplar-storage
+    read_only: true
     volumes:
-      - ./config/prometheus/prometheus.yaml:/etc/prometheus.yaml
+      - ./config/prometheus/prometheus.yaml:/etc/prometheus.yaml:ro
+      - prometheus_data:/prometheus
 
-  # And put them in an OTEL collector pipeline...
   otel-collector:
-    image: otel/opentelemetry-collector:latest
-    command: [ "--config=/etc/otel-collector.yaml" ]
+    image: otel/opentelemetry-collector-contrib:latest
+    command: [ "--config=/etc/otel-collector.yaml", "--feature-gates=receiver.dockerstats.useScraperV2" ]
+    user: 0:0
+    read_only: true
     volumes:
-      - ./config/otel-collector/otel-collector.yaml:/etc/otel-collector.yaml
+      - ./config/otel-collector/otel-collector.yaml:/etc/otel-collector.yaml:ro
+      - /var/run/docker.sock:/var/run/docker.sock
+      - /:/hostfs
 
   promtail:
     image: grafana/promtail:latest
+    command: -config.file=/etc/promtail/config.yaml
+    read_only: true
     volumes:
       - ./config/promtail/promtail.yaml:/etc/promtail/config.yaml:ro
       - /var/lib/docker/containers/:/var/lib/docker/containers
       - /var/run/docker.sock:/var/run/docker.sock
-    command: -config.file=/etc/promtail/config.yaml
+      - promtail_positions:/var/promtail
     environment:
       JAEGER_AGENT_HOST: otel-collector
       JAEGER_ENDPOINT: http://otel-collector:14268/api/traces
@@ -71,4 +83,8 @@ services:
       JAEGER_SAMPLER_PARAM: "1"
 
 volumes:
+  grafana_data:
+  prometheus_data:
+  loki_data:
   tempo_data:
+  promtail_positions:

--- a/software/roles/docker_compose_apps/templates/observability/docker-compose.yml
+++ b/software/roles/docker_compose_apps/templates/observability/docker-compose.yml
@@ -2,6 +2,7 @@ version: "3"
 services:
   grafana:
     image: grafana/grafana:latest
+    restart: unless-stopped
     volumes:
       - ./config/grafana/datasources.yaml:/etc/grafana/provisioning/datasources/datasources.yaml:ro
       - grafana_data:/var/lib/grafana
@@ -26,6 +27,7 @@ services:
   tempo:
     image: grafana/tempo:latest
     command: [ "-config.file=/etc/tempo.yaml" ]
+    restart: unless-stopped
     volumes:
       - ./config/tempo/tempo.yaml:/etc/tempo.yaml:ro
       - tempo_data:/tmp/tempo
@@ -42,6 +44,7 @@ services:
   loki:
     image: grafana/loki:latest
     command: [ "-config.file=/etc/loki/local-config.yaml" ]
+    restart: unless-stopped
     read_only: true
     volumes:
       - loki_data:/loki
@@ -60,6 +63,7 @@ services:
       - --config.file=/etc/prometheus.yaml
       - --web.enable-remote-write-receiver
       - --enable-feature=exemplar-storage
+    restart: unless-stopped
     read_only: true
     volumes:
       - ./config/prometheus/prometheus.yaml:/etc/prometheus.yaml:ro
@@ -70,6 +74,7 @@ services:
   otel-collector:
     image: otel/opentelemetry-collector-contrib:latest
     command: [ "--config=/etc/otel-collector.yaml" ]
+    restart: unless-stopped
     read_only: true
     volumes:
       - ./config/otel-collector/otel-collector.yaml:/etc/otel-collector.yaml:ro
@@ -80,6 +85,7 @@ services:
   promtail:
     image: grafana/promtail:latest
     command: -config.file=/etc/promtail/config.yaml
+    restart: unless-stopped
     read_only: true
     volumes:
       - ./config/promtail/promtail.yaml:/etc/promtail/config.yaml:ro

--- a/software/roles/docker_compose_apps/templates/observability/docker-compose.yml
+++ b/software/roles/docker_compose_apps/templates/observability/docker-compose.yml
@@ -1,0 +1,74 @@
+version: "3"
+services:
+  grafana:
+    image: grafana/grafana:latest
+    ports:
+      - 3000:3000
+    volumes:
+      - ./config/grafana/datasources.yaml:/etc/grafana/provisioning/datasources/datasources.yaml
+    #  - ./config/grafana/grafana.ini:/etc/grafana/grafana.ini
+    environment:
+      GF_AUTH_ANONYMOUS_ENABLED: "true"
+      GF_AUTH_ANONYMOUS_ORG_ROLE: Admin
+      GF_AUTH_DISABLE_LOGIN_FORM: "true"
+      JAEGER_AGENT_HOST: otel-collector
+      JAEGER_ENDPOINT: http://otel-collector:14268/api/traces
+      JAEGER_TAGS: service.name=grafana
+      JAEGER_SAMPLER_TYPE: const
+      JAEGER_SAMPLER_PARAM: "1"
+
+  tempo:
+    image: grafana/tempo:latest
+    command: [ "-config.file=/etc/tempo.yaml" ]
+    volumes:
+      - ./config/tempo/tempo.yaml:/etc/tempo.yaml
+      - tempo_data:/tmp/tempo
+    environment:
+      JAEGER_AGENT_HOST: otel-collector
+      JAEGER_ENDPOINT: http://otel-collector:14268/api/traces
+      JAEGER_TAGS: service.name=tempo
+      JAEGER_SAMPLER_TYPE: const
+      JAEGER_SAMPLER_PARAM: "1"
+
+  loki:
+    image: grafana/loki:latest
+    command: [ "-config.file=/etc/loki/local-config.yaml" ]
+    environment:
+      JAEGER_AGENT_HOST: otel-collector
+      JAEGER_ENDPOINT: http://otel-collector:14268/api/traces
+      JAEGER_TAGS: service.name=loki
+      JAEGER_SAMPLER_TYPE: const
+      JAEGER_SAMPLER_PARAM: "1"
+
+  prometheus:
+    image: prom/prometheus:latest
+    command:
+      - --config.file=/etc/prometheus.yaml
+      - --web.enable-remote-write-receiver
+      - --enable-feature=exemplar-storage
+    volumes:
+      - ./config/prometheus/prometheus.yaml:/etc/prometheus.yaml
+
+  # And put them in an OTEL collector pipeline...
+  otel-collector:
+    image: otel/opentelemetry-collector:latest
+    command: [ "--config=/etc/otel-collector.yaml" ]
+    volumes:
+      - ./config/otel-collector/otel-collector.yaml:/etc/otel-collector.yaml
+
+  promtail:
+    image: grafana/promtail:latest
+    volumes:
+      - ./config/promtail/promtail.yaml:/etc/promtail/config.yaml:ro
+      - /var/lib/docker/containers/:/var/lib/docker/containers
+      - /var/run/docker.sock:/var/run/docker.sock
+    command: -config.file=/etc/promtail/config.yaml
+    environment:
+      JAEGER_AGENT_HOST: otel-collector
+      JAEGER_ENDPOINT: http://otel-collector:14268/api/traces
+      JAEGER_TAGS: service.name=promtail
+      JAEGER_SAMPLER_TYPE: const
+      JAEGER_SAMPLER_PARAM: "1"
+
+volumes:
+  tempo_data:

--- a/software/roles/docker_compose_apps/templates/observability/docker-compose.yml
+++ b/software/roles/docker_compose_apps/templates/observability/docker-compose.yml
@@ -2,12 +2,10 @@ version: "3"
 services:
   grafana:
     image: grafana/grafana:latest
-    ports:
-      - 3000:3000
     volumes:
       - ./config/grafana/datasources.yaml:/etc/grafana/provisioning/datasources/datasources.yaml:ro
       - grafana_data:/var/lib/grafana
-    #  - ./config/grafana/grafana.ini:/etc/grafana/grafana.ini
+      - ./config/grafana/grafana.ini:/etc/grafana/grafana.ini
     environment:
       GF_AUTH_ANONYMOUS_ENABLED: "true"
       GF_AUTH_ANONYMOUS_ORG_ROLE: Admin
@@ -17,6 +15,15 @@ services:
       JAEGER_TAGS: service.name=grafana
       JAEGER_SAMPLER_TYPE: const
       JAEGER_SAMPLER_PARAM: "1"
+    labels:
+      - traefik.enable=true
+      - traefik.http.routers.grafana.rule=Host(`grafana.$BASE_DOMAIN`)
+      - traefik.http.routers.grafana.entrypoints=https
+      - traefik.http.routers.grafana.tls.certResolver=letsencrypt
+      - traefik.http.routers.grafana.middlewares=authelia@docker
+    networks:
+      - internal
+      - rproxy
 
   tempo:
     image: grafana/tempo:latest
@@ -31,6 +38,8 @@ services:
       JAEGER_TAGS: service.name=tempo
       JAEGER_SAMPLER_TYPE: const
       JAEGER_SAMPLER_PARAM: "1"
+    networks:
+      - internal
 
   loki:
     image: grafana/loki:latest
@@ -44,6 +53,8 @@ services:
       JAEGER_TAGS: service.name=loki
       JAEGER_SAMPLER_TYPE: const
       JAEGER_SAMPLER_PARAM: "1"
+    networks:
+      - internal
 
   prometheus:
     image: prom/prometheus:latest
@@ -55,6 +66,8 @@ services:
     volumes:
       - ./config/prometheus/prometheus.yaml:/etc/prometheus.yaml:ro
       - prometheus_data:/prometheus
+    networks:
+      - internal
 
   otel-collector:
     image: otel/opentelemetry-collector-contrib:latest
@@ -65,6 +78,9 @@ services:
       - ./config/otel-collector/otel-collector.yaml:/etc/otel-collector.yaml:ro
       - /var/run/docker.sock:/var/run/docker.sock
       - /:/hostfs
+    networks:
+      - internal
+      - observability
 
   promtail:
     image: grafana/promtail:latest
@@ -81,6 +97,8 @@ services:
       JAEGER_TAGS: service.name=promtail
       JAEGER_SAMPLER_TYPE: const
       JAEGER_SAMPLER_PARAM: "1"
+    networks:
+      - internal
 
 volumes:
   grafana_data:
@@ -88,3 +106,10 @@ volumes:
   loki_data:
   tempo_data:
   promtail_positions:
+
+networks:
+  internal:
+  observability:
+    name: observability
+  rproxy:
+    external: true

--- a/software/roles/docker_compose_apps/templates/traefik/.env.j2
+++ b/software/roles/docker_compose_apps/templates/traefik/.env.j2
@@ -1,0 +1,1 @@
+BASE_DOMAIN={{ base_domain }}

--- a/software/roles/docker_compose_apps/templates/traefik/docker-compose.yml
+++ b/software/roles/docker_compose_apps/templates/traefik/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3.7"
 
 services:
   traefik:
-    image: traefik:v2.9
+    image: traefik:v3.0.0-beta2
     restart: unless-stopped
     ports:
       - 0.0.0.0:80:80
@@ -15,6 +15,7 @@ services:
       - letsencrypt:/letsencrypt
     networks:
       - rproxy
+      - observability
 
 volumes:
   letsencrypt:
@@ -22,3 +23,5 @@ volumes:
 networks:
   rproxy:
     name: rproxy
+  observability:
+    external: true

--- a/software/roles/docker_compose_apps/templates/traefik/docker-compose.yml
+++ b/software/roles/docker_compose_apps/templates/traefik/docker-compose.yml
@@ -13,6 +13,13 @@ services:
       - ./traefik.yml:/etc/traefik/traefik.yml:ro
       - /var/run/docker.sock:/var/run/docker.sock:ro
       - letsencrypt:/letsencrypt
+    labels:
+      - traefik.enable=true
+      - traefik.http.routers.traefik.service=api@internal
+      - traefik.http.routers.traefik.rule=Host(`traefik.$BASE_DOMAIN`)
+      - traefik.http.routers.traefik.entrypoints=https
+      - traefik.http.routers.traefik.tls.certResolver=letsencrypt
+      - traefik.http.routers.traefik.middlewares=authelia@docker
     networks:
       - rproxy
       - observability

--- a/software/roles/docker_compose_apps/templates/traefik/traefik.yml.j2
+++ b/software/roles/docker_compose_apps/templates/traefik/traefik.yml.j2
@@ -48,3 +48,6 @@ log:
 #     addEntryPointsLabels: true
 #     addRoutersLabels: true
 #     addServicesLabels: true
+
+api:
+  dashboard: true

--- a/software/roles/docker_compose_apps/templates/traefik/traefik.yml.j2
+++ b/software/roles/docker_compose_apps/templates/traefik/traefik.yml.j2
@@ -1,5 +1,6 @@
-experimental:
-  http3: true
+global:
+  sendAnonymousUsage: false
+  checkNewVersion: false
 
 entryPoints:
   http:
@@ -29,3 +30,21 @@ providers:
   docker:
     exposedByDefault: false
     network: rproxy
+
+tracing:
+  openTelemetry:
+    address: http://otel-collector:4318
+    insecure: true
+    grpc: {}
+
+log:
+  format: json
+
+# metrics:
+#   openTelemetry:
+#     address: otel-collector:4318
+#     insecure: true
+#     grpc: {}
+#     addEntryPointsLabels: true
+#     addRoutersLabels: true
+#     addServicesLabels: true

--- a/software/roles/docker_compose_apps/vars/main.yml
+++ b/software/roles/docker_compose_apps/vars/main.yml
@@ -1,7 +1,7 @@
 ---
 apps:
-  - traefik
   - observability
+  - traefik
   - lldap
   - authelia
   - grocy

--- a/software/roles/docker_compose_apps/vars/main.yml
+++ b/software/roles/docker_compose_apps/vars/main.yml
@@ -1,6 +1,7 @@
 ---
 apps:
   - traefik
+  - observability
   - lldap
   - authelia
   - grocy

--- a/software/roles/docker_daemon/files/daemon.json
+++ b/software/roles/docker_daemon/files/daemon.json
@@ -1,5 +1,12 @@
 {
   "ip": "127.0.0.1",
   "ipv6": true,
-  "fixed-cidr-v6": "fddc:a418:b327::/48"
+  "fixed-cidr-v6": "fddc:a418:b327::/48",
+  "log-driver": "json-file",
+  "log-opts": {
+    "labels-regex": "^.+",
+    "tag": "{{.ImageName}}|{{.Name}}|{{.ImageFullID}}",
+    "max-size": "10m",
+    "max-file": "3"
+  }
 }


### PR DESCRIPTION
- Add observability for metrics, logs, and traces.
- Polishing volumes for observability setup
- localhost-access
- Increase memory limit for testing
- Make grafana available from reverse proxy
- Simplify otel-collector to reduce errors
- Add traefik observability
- Expose traefik dashboard

Implemented the majority of #22 